### PR TITLE
ovn: fix negation bug, made simpler code base for programming chain

### DIFF
--- a/ovn/ovn-nb.ovsschema
+++ b/ovn/ovn-nb.ovsschema
@@ -1,7 +1,7 @@
 {
     "name": "OVN_Northbound",
     "version": "5.3.4",
-    "cksum": "3948302930 15413",
+    "cksum": "2829164590 15550",
     "tables": {
         "NB_Global": {
             "columns": {
@@ -121,7 +121,10 @@
                                    "max": "unlimited"}},
                 "external_ids": {
                     "type": {"key": "string", "value": "string",
-                             "min": 0, "max": "unlimited"}}},
+                             "min": 0, "max": "unlimited"}},
+                "sortkey": {"type": {"key": {"type": "integer"},
+                                     "min": 0, "max": 1}}
+            },
             "isRoot": false},
         "Logical_Port_Pair": {
             "columns": {

--- a/ovn/ovn-nb.ovsschema
+++ b/ovn/ovn-nb.ovsschema
@@ -1,7 +1,7 @@
 {
     "name": "OVN_Northbound",
     "version": "5.3.4",
-    "cksum": "2829164590 15550",
+    "cksum": "2556006120 17179",
     "tables": {
         "NB_Global": {
             "columns": {
@@ -36,6 +36,11 @@
                                           "refType": "strong"},
                                   "min": 0,
                                   "max": "unlimited"}},
+                "acl_chains": {"type": {"key": {"type": "uuid",
+                                                "refTable": "ACL_Chain",
+                                                "refType": "strong"},
+                                        "min": 0,
+                                        "max": "unlimited"}},
                 "load_balancer": {"type": {"key": {"type": "uuid",
                                                   "refTable": "Load_Balancer",
                                                   "refType": "strong"},
@@ -210,6 +215,28 @@
                 "match": {"type": "string"},
                 "action": {"type": {"key": {"type": "string",
                                             "enum": ["set", ["allow", "allow-related", "drop", "reject"]]}}},
+                "log": {"type": "boolean"},
+                "external_ids": {
+                    "type": {"key": "string", "value": "string",
+                             "min": 0, "max": "unlimited"}}},
+            "isRoot": false},
+        "ACL_Chain": {
+            "columns": {
+                "priority": {"type": {"key": {"type": "integer",
+                                              "minInteger": 0,
+                                              "maxInteger": 32767}}},
+                "direction": {"type": {"key": {"type": "string",
+                                            "enum": ["set", ["from-lport", "to-lport"]]}}},
+                "match": {"type": "string"},
+                "port_chain":  {"type": {"key": {"type": "uuid",
+                                                 "refTable": "Logical_Port_Chain",
+                                                 "refType": "strong"},
+                                         "min": 1, "max": 1}},
+                "last_hop_port": {"type": {"key": {"type": "uuid",
+                                                   "refTable": "Logical_Switch_Port",
+                                                   "refType": "strong"},
+                                           "min": 0, "max": 1}},
+                "bidirectional": {"type": "boolean"},
                 "log": {"type": "boolean"},
                 "external_ids": {
                     "type": {"key": "string", "value": "string",

--- a/ovn/ovn-nb.ovsschema
+++ b/ovn/ovn-nb.ovsschema
@@ -1,7 +1,7 @@
 {
     "name": "OVN_Northbound",
     "version": "5.3.4",
-    "cksum": "2556006120 17179",
+    "cksum": "2829164590 15550",
     "tables": {
         "NB_Global": {
             "columns": {
@@ -36,11 +36,6 @@
                                           "refType": "strong"},
                                   "min": 0,
                                   "max": "unlimited"}},
-                "acl_chains": {"type": {"key": {"type": "uuid",
-                                                "refTable": "ACL_Chain",
-                                                "refType": "strong"},
-                                        "min": 0,
-                                        "max": "unlimited"}},
                 "load_balancer": {"type": {"key": {"type": "uuid",
                                                   "refTable": "Load_Balancer",
                                                   "refType": "strong"},
@@ -215,28 +210,6 @@
                 "match": {"type": "string"},
                 "action": {"type": {"key": {"type": "string",
                                             "enum": ["set", ["allow", "allow-related", "drop", "reject"]]}}},
-                "log": {"type": "boolean"},
-                "external_ids": {
-                    "type": {"key": "string", "value": "string",
-                             "min": 0, "max": "unlimited"}}},
-            "isRoot": false},
-        "ACL_Chain": {
-            "columns": {
-                "priority": {"type": {"key": {"type": "integer",
-                                              "minInteger": 0,
-                                              "maxInteger": 32767}}},
-                "direction": {"type": {"key": {"type": "string",
-                                            "enum": ["set", ["from-lport", "to-lport"]]}}},
-                "match": {"type": "string"},
-                "port_chain":  {"type": {"key": {"type": "uuid",
-                                                 "refTable": "Logical_Port_Chain",
-                                                 "refType": "strong"},
-                                         "min": 1, "max": 1}},
-                "last_hop_port": {"type": {"key": {"type": "uuid",
-                                                   "refTable": "Logical_Switch_Port",
-                                                   "refType": "strong"},
-                                           "min": 0, "max": 1}},
-                "bidirectional": {"type": "boolean"},
                 "log": {"type": "boolean"},
                 "external_ids": {
                     "type": {"key": "string", "value": "string",

--- a/ovn/ovn-nb.xml
+++ b/ovn/ovn-nb.xml
@@ -121,7 +121,7 @@
     </column>
     <column name="port_pairs">
       <p>
-        The logical chains that define the service path.
+        The logical port pairs that are used by the service path.
       </p>
 
       <p>
@@ -136,6 +136,10 @@
 
     <column name="acls">
       Access control rules that apply to packets within the logical switch.
+    </column>
+
+    <column name="acl_chains">
+      Access control rules that apply to packets that need to be part of port chain.
     </column>
 
     <group title="other_config">
@@ -185,12 +189,7 @@
     </column>
     <column name="flow_classifier">
       <p>
-        The logical flow classifier that steeers the flows to the port_pair_groups.
-      </p>
-
-      <p>
-        It is an error for multiple logical port chains to include the same
-        flow classifier.
+        FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
       </p>
     </column>
     <group title="Common Columns">
@@ -256,66 +255,66 @@
 
  <table name="Logical_Flow_Classifier" title="logical flow classifier">
    <p>
-     Flow classifier defining traffic steering rules
+     FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
    </p>
    <column name="name">
      <p>
-       Logical flow classifier
+       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
      </p>
    </column>
    <column name="logical_source_port">
      <p>
-       Source port for flow
+       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
      </p>
    </column>
    <column name="logical_destination_port">
      <p>
-       Destination port for flow
+       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
      </p>
    </column>
    <column name="source_port_range_min">
      <p>
-       minimum port value for source port
+       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
      </p>
    </column>
    <column name="source_port_range_max">
      <p>
-       maximum port value for source port
+       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
      </p>
    </column>
    <column name="destination_port_range_min">
      <p>
-       minimum port value for destination port
+       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
      </p>
    </column>
    <column name="destination_port_range_max">
      <p>
-       maximum port value for destination port
+       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
      </p>
    </column>
   <column name="source_ip_prefix">
      <p>
-       source ip prefix
+       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
      </p>
    </column>
    <column name="destination_ip_prefix">
      <p>
-       destination ip prefix
+       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
      </p>
    </column>
    <column name="protocol">
      <p>
-       protocol
+       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
      </p>
    </column>
    <column name="ethertype">
      <p>
-       ethertype
+       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
      </p>
    </column>
    <group title="Common Columns">
       <column name="external_ids">
-        See <em>External IDs</em> at the beginning of this document.
+        FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
       </column>
     </group>
  </table>
@@ -828,11 +827,12 @@
     </pre>
 
     <p>
-      Address sets may be used in the <ref column="match" table="ACL"/> column
-      of the <ref table="ACL"/> table.  For syntax information, see the details
-      of the expression language used for the <ref column="match"
-      table="Logical_Flow" db="OVN_Southbound"/> column in the <ref
-      table="Logical_Flow" db="OVN_Southbound"/> table of the <ref
+      Address sets may be used in the <ref column="match" table="ACL"/> and
+      <ref column="match" table="ACL_Chain"/> columns of the
+      <ref table="ACL"/> and <ref table="ACL_Chain"/> tables, respectively.
+      For syntax information, see the details of the expression language used
+      for the <ref column="match" table="Logical_Flow" db="OVN_Southbound"/> column
+      in the <ref table="Logical_Flow" db="OVN_Southbound"/> table of the <ref
       db="OVN_Southbound"/> database.
     </p>
 
@@ -982,6 +982,123 @@
           <code>Not implemented--currently treated as drop</code>
         </li>
       </ul>
+    </column>
+
+    <column name="log">
+      <p>
+        If set to <code>true</code>, packets that match the ACL will trigger a
+        log message on the transport node or nodes that perform ACL processing.
+        Logging may be combined with any <ref column="action"/>.
+      </p>
+
+      <p>
+        Logging is not yet implemented.
+      </p>
+    </column>
+
+    <group title="Common Columns">
+      <column name="external_ids">
+        See <em>External IDs</em> at the beginning of this document.
+      </column>
+    </group>
+  </table>
+
+  <table name="ACL_Chain" title="Access Control List (ACL) for Logical port Chain">
+    <p>
+      Each row in this table represents one ACL chain rule for a logical switch
+      that points to it through its <ref column="acl_chains"/> column. In SFC's
+      context, this table is commonly referred as classifiers.
+      The <ref column="port_chain"/> column for the highest-<ref column="priority"/>
+      matching row in this table determines a port chain used by the matching packet.
+      Multiple rows can be used to steer packets into the same port chain.
+    </p>
+
+    <column name="priority">
+      <p>
+        The ACL rule's priority.  Rules with numerically higher priority
+        take precedence over those with lower.  If two ACL chain rules with
+        the same priority both match, then the one actually applied to a
+        packet is undefined.
+      </p>
+    </column>
+
+    <column name="direction">
+      <p>Direction of the traffic to which this rule should apply:</p>
+      <ul>
+        <li>
+          <code>from-lport</code>: Used to implement filters on traffic
+          arriving from a logical port.  These rules are applied to the
+          logical switch's ingress pipeline.
+        </li>
+        <li>
+          <code>to-lport</code>: Used to implement filters on traffic
+          forwarded to a logical port.  These rules are applied to the
+          logical switch's egress pipeline.
+        </li>
+      </ul>
+    </column>
+
+    <column name="match">
+      <p>
+        The packets that the ACL chain should match, in the same expression
+        language used for the <ref column="match" table="Logical_Flow"
+        db="OVN_Southbound"/> column in the OVN Southbound database's
+        <ref table="Logical_Flow" db="OVN_Southbound"/> table.  The
+        <code>outport</code> logical port is only available in the
+        <code>to-lport</code> direction (the <code>inport</code> is
+        available in both directions).
+      </p>
+
+      <p>
+        This table represents the entry point for all port chains. Thus,
+        if there are no rows referring to a port chain, no packets will
+        be classified to go through the corresponding port chain groups.
+      </p>
+
+      <p>
+        Note that you can not create an ACL matching on a port with
+        type=router.
+      </p>
+
+      <p>
+        Note that when <code>localnet</code> port exists in a lswitch, for
+        <code>to-lport</code> direction, the <code>inport</code> works only if
+        the <code>to-lport</code> is located on the same chassis as the
+        <code>inport</code>.
+      </p>
+    </column>
+
+    <column name="port_chain">
+      <p>
+        The chain entry in <ref table="Logical_Port_Chain"/> that will handle
+        matched packets.
+      </p>
+    </column>
+
+    <column name="last_hop_port">
+      <p>
+        Destination logical port that is used at the very end of the chain.
+      </p>
+    </column>
+
+    <column name="bidirectional">
+      <p>
+        If set to <code>true</code>, the rules created for supporting the chain
+        will also include the reverse path. In essence, it removes the need for
+        a symmetric chain to control the packet flow from destination to source.
+      </p>
+
+      <p>
+        Note that the last hop of the chain in the reverse direction will need
+        to be known. In other words, in order to be bidirectional, the
+        <code>inport</code> from the <ref column="match"/> column is expected
+        to be used as the <ref column="last_hop_port"/> for rules in the reverse
+        direction.
+      </p>
+
+      <p>
+        Bidirectional is not yet implemented.
+      </p>
     </column>
 
     <column name="log">

--- a/ovn/ovn-nb.xml
+++ b/ovn/ovn-nb.xml
@@ -121,7 +121,7 @@
     </column>
     <column name="port_pairs">
       <p>
-        The logical port pairs that are used by the service path.
+        The logical chains that define the service path.
       </p>
 
       <p>
@@ -136,10 +136,6 @@
 
     <column name="acls">
       Access control rules that apply to packets within the logical switch.
-    </column>
-
-    <column name="acl_chains">
-      Access control rules that apply to packets that need to be part of port chain.
     </column>
 
     <group title="other_config">
@@ -189,7 +185,12 @@
     </column>
     <column name="flow_classifier">
       <p>
-        FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+        The logical flow classifier that steeers the flows to the port_pair_groups.
+      </p>
+
+      <p>
+        It is an error for multiple logical port chains to include the same
+        flow classifier.
       </p>
     </column>
     <group title="Common Columns">
@@ -255,66 +256,66 @@
 
  <table name="Logical_Flow_Classifier" title="logical flow classifier">
    <p>
-     FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+     Flow classifier defining traffic steering rules
    </p>
    <column name="name">
      <p>
-       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+       Logical flow classifier
      </p>
    </column>
    <column name="logical_source_port">
      <p>
-       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+       Source port for flow
      </p>
    </column>
    <column name="logical_destination_port">
      <p>
-       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+       Destination port for flow
      </p>
    </column>
    <column name="source_port_range_min">
      <p>
-       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+       minimum port value for source port
      </p>
    </column>
    <column name="source_port_range_max">
      <p>
-       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+       maximum port value for source port
      </p>
    </column>
    <column name="destination_port_range_min">
      <p>
-       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+       minimum port value for destination port
      </p>
    </column>
    <column name="destination_port_range_max">
      <p>
-       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+       maximum port value for destination port
      </p>
    </column>
   <column name="source_ip_prefix">
      <p>
-       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+       source ip prefix
      </p>
    </column>
    <column name="destination_ip_prefix">
      <p>
-       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+       destination ip prefix
      </p>
    </column>
    <column name="protocol">
      <p>
-       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+       protocol
      </p>
    </column>
    <column name="ethertype">
      <p>
-       FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+       ethertype
      </p>
    </column>
    <group title="Common Columns">
       <column name="external_ids">
-        FIXME: THIS NEEDS TO BE REMOVED -- it is no longer used
+        See <em>External IDs</em> at the beginning of this document.
       </column>
     </group>
  </table>
@@ -827,12 +828,11 @@
     </pre>
 
     <p>
-      Address sets may be used in the <ref column="match" table="ACL"/> and
-      <ref column="match" table="ACL_Chain"/> columns of the
-      <ref table="ACL"/> and <ref table="ACL_Chain"/> tables, respectively.
-      For syntax information, see the details of the expression language used
-      for the <ref column="match" table="Logical_Flow" db="OVN_Southbound"/> column
-      in the <ref table="Logical_Flow" db="OVN_Southbound"/> table of the <ref
+      Address sets may be used in the <ref column="match" table="ACL"/> column
+      of the <ref table="ACL"/> table.  For syntax information, see the details
+      of the expression language used for the <ref column="match"
+      table="Logical_Flow" db="OVN_Southbound"/> column in the <ref
+      table="Logical_Flow" db="OVN_Southbound"/> table of the <ref
       db="OVN_Southbound"/> database.
     </p>
 
@@ -982,123 +982,6 @@
           <code>Not implemented--currently treated as drop</code>
         </li>
       </ul>
-    </column>
-
-    <column name="log">
-      <p>
-        If set to <code>true</code>, packets that match the ACL will trigger a
-        log message on the transport node or nodes that perform ACL processing.
-        Logging may be combined with any <ref column="action"/>.
-      </p>
-
-      <p>
-        Logging is not yet implemented.
-      </p>
-    </column>
-
-    <group title="Common Columns">
-      <column name="external_ids">
-        See <em>External IDs</em> at the beginning of this document.
-      </column>
-    </group>
-  </table>
-
-  <table name="ACL_Chain" title="Access Control List (ACL) for Logical port Chain">
-    <p>
-      Each row in this table represents one ACL chain rule for a logical switch
-      that points to it through its <ref column="acl_chains"/> column. In SFC's
-      context, this table is commonly referred as classifiers.
-      The <ref column="port_chain"/> column for the highest-<ref column="priority"/>
-      matching row in this table determines a port chain used by the matching packet.
-      Multiple rows can be used to steer packets into the same port chain.
-    </p>
-
-    <column name="priority">
-      <p>
-        The ACL rule's priority.  Rules with numerically higher priority
-        take precedence over those with lower.  If two ACL chain rules with
-        the same priority both match, then the one actually applied to a
-        packet is undefined.
-      </p>
-    </column>
-
-    <column name="direction">
-      <p>Direction of the traffic to which this rule should apply:</p>
-      <ul>
-        <li>
-          <code>from-lport</code>: Used to implement filters on traffic
-          arriving from a logical port.  These rules are applied to the
-          logical switch's ingress pipeline.
-        </li>
-        <li>
-          <code>to-lport</code>: Used to implement filters on traffic
-          forwarded to a logical port.  These rules are applied to the
-          logical switch's egress pipeline.
-        </li>
-      </ul>
-    </column>
-
-    <column name="match">
-      <p>
-        The packets that the ACL chain should match, in the same expression
-        language used for the <ref column="match" table="Logical_Flow"
-        db="OVN_Southbound"/> column in the OVN Southbound database's
-        <ref table="Logical_Flow" db="OVN_Southbound"/> table.  The
-        <code>outport</code> logical port is only available in the
-        <code>to-lport</code> direction (the <code>inport</code> is
-        available in both directions).
-      </p>
-
-      <p>
-        This table represents the entry point for all port chains. Thus,
-        if there are no rows referring to a port chain, no packets will
-        be classified to go through the corresponding port chain groups.
-      </p>
-
-      <p>
-        Note that you can not create an ACL matching on a port with
-        type=router.
-      </p>
-
-      <p>
-        Note that when <code>localnet</code> port exists in a lswitch, for
-        <code>to-lport</code> direction, the <code>inport</code> works only if
-        the <code>to-lport</code> is located on the same chassis as the
-        <code>inport</code>.
-      </p>
-    </column>
-
-    <column name="port_chain">
-      <p>
-        The chain entry in <ref table="Logical_Port_Chain"/> that will handle
-        matched packets.
-      </p>
-    </column>
-
-    <column name="last_hop_port">
-      <p>
-        Destination logical port that is used at the very end of the chain.
-      </p>
-    </column>
-
-    <column name="bidirectional">
-      <p>
-        If set to <code>true</code>, the rules created for supporting the chain
-        will also include the reverse path. In essence, it removes the need for
-        a symmetric chain to control the packet flow from destination to source.
-      </p>
-
-      <p>
-        Note that the last hop of the chain in the reverse direction will need
-        to be known. In other words, in order to be bidirectional, the
-        <code>inport</code> from the <ref column="match"/> column is expected
-        to be used as the <ref column="last_hop_port"/> for rules in the reverse
-        direction.
-      </p>
-
-      <p>
-        Bidirectional is not yet implemented.
-      </p>
     </column>
 
     <column name="log">

--- a/ovn/ovn-nb.xml
+++ b/ovn/ovn-nb.xml
@@ -214,7 +214,14 @@
        port pair for this group
      </p>
    </column>
-    <group title="Common Columns">
+    <column name="sortkey">
+      <p>
+        An integer used for ordering instances of <ref table="Logical_Port_Pair_Group"/>
+        in the <ref column="port_pairs" table="Logical_Port_Chain"/> column
+        of <ref table="Logical_Port_Chain"/>.
+      </p>
+    </column>
+   <group title="Common Columns">
       <column name="external_ids">
         See <em>External IDs</em> at the beginning of this document.
       </column>

--- a/ovn/utilities/ovn-nbctl.c
+++ b/ovn/utilities/ovn-nbctl.c
@@ -336,8 +336,8 @@ Logical port-chain commands:\n\
                                            de-associate classifier CLASSIFIER with LSP-CHAIN\n\
 \n\
 Logical port-pair-groups commands:\n\
-  lsp-pair-group-add LSP-CHAIN LSP-PAIR-GROUP-NAME\n\
-                           create a logical port-pair-group \n\
+  lsp-pair-group-add LSP-CHAIN LSP-PAIR-GROUP-NAME OFFSET\n\
+                           create a logical port-pair-group. Optionally, indicate the order it should be in chain.\n\
   lsp-pair-group-del LSP-PAIR-GROUP-NAME    delete a port-pair-group, does not delete port-pairs\n\
                                             or flow-classifier\n\
   lsp-pair-group-list LSP-CHAIN   print the names of all logical port-pair-groups\n\
@@ -1150,8 +1150,15 @@ nbctl_lsp_pair_group_add(struct ctl_context *ctx)
 
     /* create the logical port-pair-group. */
     lsp_pair_group = nbrec_logical_port_pair_group_insert(ctx->txn);
-    if (ctx->argc == 3){
+    if (ctx->argc >= 3){
         nbrec_logical_port_pair_group_set_name(lsp_pair_group, ctx->argv[2]);
+    }
+
+    int64_t sortkey = (int64_t) lsp_chain->n_port_pair_groups + 1;
+    if (ctx->argc >= 4) {
+        sortkey = (int64_t) atoi(ctx->argv[3]);
+    } else {
+        nbrec_logical_port_pair_group_set_sortkey(lsp_pair_group, &sortkey, 1);
     }
 
     /* Insert the logical port into the logical switch. */
@@ -3299,7 +3306,7 @@ static const struct ctl_command_syntax nbctl_commands[] = {
       nbctl_lsp_chain_unset_flow_classifier, NULL, "", RW },
 
     /* lsp-pair-group commands. */
-    { "lsp-pair-group-add", 1, 2, "LSP-CHAIN [LSP-PAIR-GROUP]",
+    { "lsp-pair-group-add", 1, 3, "LSP-CHAIN [LSP-PAIR-GROUP] [OFFSET]",
       NULL, nbctl_lsp_pair_group_add, NULL, "", RW },
     { "lsp-pair-group-del", 2, 2, "LSP-CHAIN, LSP-PAIR-GROUP", NULL, nbctl_lsp_pair_group_del,
       NULL, "", RW },

--- a/ovn/utilities/ovn-nbctl.c
+++ b/ovn/utilities/ovn-nbctl.c
@@ -1530,8 +1530,9 @@ nbctl_lflow_classifier_set_logical_destination_port(struct ctl_context *ctx)
 
     lflow_classifier = lflow_classifier_by_name_or_uuid(ctx, id);
 
-    /* Check port exists if given*/
-    if (!strcmp(ctx->argv[2],"") ){
+    /* Check port exists if given name is not an empty string. If empty string is given, that
+       indicates we should be clearing the info. */
+    if (strcmp(ctx->argv[2],"") != 0) {
         lsp = lsp_by_name_or_uuid(ctx, ctx->argv[2], true);
         if (!lsp){
             ctl_fatal("Invalid port %s ", ctx->argv[2]);


### PR DESCRIPTION
- Made is simpler for creation of rules that is based on logical ports
- Fix negate bug on setting of destination port of classifier
- Made it work in cases when port pair has same in/out value (see: 
  https://github.com/flavio-fernandes/just-ovn-nodes/commit/629678effc3eaa8a418b01c15ab41496b9144501)
- Changed ordering of match clause, so it is consistent from classifiers and port chains
